### PR TITLE
Added Base template

### DIFF
--- a/wagtail_box/blog/templates/blog/blog.html
+++ b/wagtail_box/blog/templates/blog/blog.html
@@ -1,75 +1,78 @@
+{% extends "partials/base.html" %}
+
 {% load wagtailcore_tags %}
 {% load wagtailimages_tags %}
 {% load blog_tags %}
 
-
-<h1>Blog posts</h1>
-{% if page.tags %}
-    <h3>Tags list</h3>
-    <ul>
-        {% spaceless %}
-            {% for tag in page.tags %}
-                <li>
-                    {% if current_tag == tag.name %}
-                        {% slugurl "blog" as blog_link %}
-                        <a href="{{ blog_link }}">
-                            __{{ tag }}__
-                        </a>
-                    {% else %}
-                        <a href="?tag={{ tag }}">{{ tag }}</a>
-                    {% endif %}
-                </li>
-            {% endfor %}
-        {% endspaceless %}
-    </ul>
-{% endif %}
-{% for article in articles %}
-    <div>
-        <article>
-            <a href="{% pageurl article %}">
-                <h2>{{ article.title }}</h2>
-            </a>
-            <div>
-                <span>{{ article.owner.get_full_name|default:article.owner }}</span>
-                <span >{{ article.date|date:"N d, Y" }}</span>
-            </div>
-
-            {% if article.cover %}
+{% block content %}
+    <h1>Blog posts</h1>
+    {% if page.tags %}
+        <h3>Tags list</h3>
+          <ul>
+            {% spaceless %}
+                {% for tag in page.tags %}
+                    <li>
+                        {% if current_tag == tag.name %}
+                            {% slugurl "blog" as blog_link %}
+                            <a href="{{ blog_link }}">
+                                __{{ tag }}__
+                            </a>
+                        {% else %}
+                            <a href="?tag={{ tag }}">{{ tag }}</a>
+                        {% endif %}
+                    </li>
+                {% endfor %}
+            {% endspaceless %}
+        </ul>
+    {% endif %}
+    {% for article in articles %}
+        <div>
+            <article>
                 <a href="{% pageurl article %}">
-                    <div>
-                        <figure>
-                            {% image article.cover width-400 as cover %}
-                            <img src="{{cover.url}}" />
-                        </figure>
-                    </div>
+                    <h2>{{ article.title }}</h2>
                 </a>
+                <div>
+                    <span>{{ article.owner.get_full_name|default:article.owner }}</span>
+                    <span >{{ article.date|date:"N d, Y" }}</span>
+                </div>
+
+                {% if article.cover %}
+                    <a href="{% pageurl article %}">
+                        <div>
+                            <figure>
+                                {% image article.cover width-400 as cover %}
+                                <img src="{{cover.url}}" />
+                            </figure>
+                        </div>
+                    </a>
+                {% endif %}
+                <p>{{ article.intro }}</p>
+            </article>
+            <a href="{% pageurl article %}">Read more...</a>
+        </div>
+    {% empty %}
+        <p>You have no blog posts.</p>
+    {% endfor %}
+
+    {% if articles.paginator.num_pages > 1 %}
+        <ul>
+            {% if articles.has_previous %}
+                <li><a href="?page=1">&laquo;</a></li>
+                <li><a href="{% replace_query_link 'page' articles.previous_page_number %}">&lsaquo;</a></li>
             {% endif %}
-            <p>{{ article.intro }}</p>
-        </article>
-        <a href="{% pageurl article %}">Read more...</a>
-    </div>
-{% empty %}
-    <p>You have no blog posts.</p>
-{% endfor %}
 
-{% if articles.paginator.num_pages > 1 %}
-    <ul>
-        {% if articles.has_previous %}
-            <li><a href="?page=1">&laquo;</a></li>
-            <li><a href="{% replace_query_link 'page' articles.previous_page_number %}">&lsaquo;</a></li>
-        {% endif %}
+            {% for item in articles.paginator.page_range %}
+                {% if articles.number == item %}
+                    <li>{{ item }}</li>
+                {% else %}
+                    <li><a href="{% replace_query_link 'page' item %}">{{ item }}</a></li>
+                {% endif %}
+            {% endfor %}
 
-        {% for item in articles.paginator.page_range %}
-            {% if articles.number == item %}
-                <li>{{ item }}</li>
-            {% else %}
-                <li><a href="{% replace_query_link 'page' item %}">{{ item }}</a></li>
+            {% if articles.has_next %}
+                <li><a href="{% replace_query_link 'page' articles.next_page_number %}">&rsaquo;</a></li>
+                <li><a href="{% replace_query_link 'page' articles.paginator.num_pages %}">&raquo;</a></li>
             {% endif %}
-        {% endfor %}
-
-        {% if articles.has_next %}
-            <li><a href="{% replace_query_link 'page' articles.next_page_number %}">&rsaquo;</a></li>
-            <li><a href="{% replace_query_link 'page' articles.paginator.num_pages %}">&raquo;</a></li>
-        {% endif %}
-    </ul>
-{% endif %}
+        </ul>
+    {% endif %}
+{% endblock %}

--- a/wagtail_box/blog/templates/blog/post.html
+++ b/wagtail_box/blog/templates/blog/post.html
@@ -1,10 +1,14 @@
-<div>
-    <article>
-        <h2>{{ page.title }}</h2>
-        <div>
-            <a>{{ page.owner.get_full_name|default:page.owner }}</a>
-            <span>{{ page.date|date:"N d, Y" }}</span>
-        </div>
-        {% include "partials/streamfield.html" with content=self.body %}
-    </article>
-</div>
+{% extends "partials/base.html" %}
+
+{% block content %}
+    <div>
+        <article>
+            <h2>{{ page.title }}</h2>
+            <div>
+                <a>{{ page.owner.get_full_name|default:page.owner }}</a>
+                <span>{{ page.date|date:"N d, Y" }}</span>
+            </div>
+            {% include "partials/streamfield.html" with content=self.body %}
+        </article>
+    </div>
+{% endblock %}

--- a/wagtail_box/pages/templates/pages/static_page.html
+++ b/wagtail_box/pages/templates/pages/static_page.html
@@ -1,2 +1,6 @@
-<h1>{{ page.title }}</h1>
-{% include "partials/streamfield.html" with content=self.body %}
+{% extends "partials/base.html" %}
+
+{% block content %}
+    <h1>{{ page.title }}</h1>
+    {% include "partials/streamfield.html" with content=self.body %}
+{% endblock %}

--- a/wagtail_box/templates/partials/base.html
+++ b/wagtail_box/templates/partials/base.html
@@ -18,5 +18,3 @@
         {% block content %}{% endblock %}
     </body>
 </html>
-
-

--- a/wagtail_box/templates/partials/base.html
+++ b/wagtail_box/templates/partials/base.html
@@ -1,0 +1,22 @@
+{% load static wagtailuserbar %}
+
+<!DOCTYPE html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
+    <head>
+      <meta charset="utf-8" />
+      <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+      <title>{% block title %}{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}{% endblock %}{% block title_suffix %}{% endblock %}</title>
+      <meta name="description" content="" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+    </head>
+
+    <body>
+        {% wagtailuserbar %}
+        {% block content %}{% endblock %}
+    </body>
+</html>
+
+


### PR DESCRIPTION
## What it does
That PR fixes [#2](https://github.com/palazzem/wagtail-nesting-box/issues/2)
A `base.html` template has been added and it contains
- right metas
- right page title
- wagtailuserbar

In that way, users are not forced anymore to override provided templates to get the parameters above

## Notes
`base.html` doesn't contain css and js link.